### PR TITLE
Harden App Attest input decoding

### DIFF
--- a/Sources/AppAttest/Assertion.swift
+++ b/Sources/AppAttest/Assertion.swift
@@ -20,6 +20,12 @@ extension Assertion {
     public init(from decoder: any Decoder) throws {
       let container = try decoder.singleValueContainer()
       let data = try container.decode(Data.self)
+      guard data.count >= 37 else {
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Authenticator data is too short."
+        )
+      }
       self.rawData = data
       // 32 bytes
       self.relyingPartyId = data[0..<32]

--- a/Sources/AppAttest/Attestation.swift
+++ b/Sources/AppAttest/Attestation.swift
@@ -32,6 +32,12 @@ extension Attestation {
     public init(from decoder: any Decoder) throws {
       let container = try decoder.singleValueContainer()
       let data = try container.decode(Data.self)
+      guard data.count >= 55 else {
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Authenticator data is too short."
+        )
+      }
       self.rawData = data
       // 32 bytes
       self.relyingPartyId = data[0..<32]
@@ -52,7 +58,16 @@ extension Attestation {
       }
 
       // 32 bytes KeyId
-      self.credentialId = data[55..<87]
+      let credentialIdLength = data[53..<55].reduce(0) { value, byte in
+        value << 8 | Int(byte)
+      }
+      guard credentialIdLength == 32, data.count >= 55 + credentialIdLength else {
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Authenticator data has an invalid credential ID."
+        )
+      }
+      self.credentialId = data[55..<(55 + credentialIdLength)]
     }
   }
 }

--- a/Sources/AppAttest/Statement.swift
+++ b/Sources/AppAttest/Statement.swift
@@ -18,14 +18,20 @@ extension Attestation {
     public init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
       let x5cs = try container.decode([Data].self, forKey: .x5c)
-      assert(x5cs.count == 2)
+      guard x5cs.count == 2 else {
+        throw DecodingError.dataCorruptedError(
+          forKey: .x5c,
+          in: container,
+          debugDescription: "Attestation statement must contain credential and intermediate certificates."
+        )
+      }
 
       let certificates = try x5cs.map {
         try X509.Certificate(derEncoded: Array($0))
       }
 
-      self.credentialCertificate = certificates.first!
-      self.intermediateCertificateAuthority = certificates.last!
+      self.credentialCertificate = certificates[0]
+      self.intermediateCertificateAuthority = certificates[1]
 
       self.receipt = try container.decode(Data.self, forKey: .receipt)
     }

--- a/Sources/AppAttest/Statement.swift
+++ b/Sources/AppAttest/Statement.swift
@@ -22,7 +22,8 @@ extension Attestation {
         throw DecodingError.dataCorruptedError(
           forKey: .x5c,
           in: container,
-          debugDescription: "Attestation statement must contain credential and intermediate certificates."
+          debugDescription:
+            "Attestation statement must contain credential and intermediate certificates."
         )
       }
 

--- a/Tests/AppAttestTests/MalformedInputTests.swift
+++ b/Tests/AppAttestTests/MalformedInputTests.swift
@@ -1,0 +1,35 @@
+import AppAttest
+import Foundation
+import Testing
+
+@Test
+func attestationAuthenticatorDataRejectsShortInput() throws {
+  let encodedData = try JSONEncoder().encode(Data(repeating: 0, count: 54))
+
+  #expect(throws: DecodingError.self) {
+    _ = try JSONDecoder().decode(Attestation.AuthenticatorData.self, from: encodedData)
+  }
+}
+
+@Test
+func assertionAuthenticatorDataRejectsShortInput() throws {
+  let encodedData = try JSONEncoder().encode(Data(repeating: 0, count: 36))
+
+  #expect(throws: DecodingError.self) {
+    _ = try JSONDecoder().decode(Assertion.AuthenticatorData.self, from: encodedData)
+  }
+}
+
+@Test
+func attestationStatementRejectsInvalidCertificateCount() throws {
+  struct StatementData: Encodable {
+    var x5c: [Data]
+    var receipt: Data
+  }
+
+  let encodedData = try JSONEncoder().encode(StatementData(x5c: [], receipt: Data()))
+
+  #expect(throws: DecodingError.self) {
+    _ = try JSONDecoder().decode(Attestation.Statement.self, from: encodedData)
+  }
+}


### PR DESCRIPTION
## Summary
- Replace trap-prone App Attest decoding with thrown decoding errors for malformed authenticator data and certificate arrays.
- Parse the credential ID length from authenticator data before reading the credential ID.
- Add malformed input tests for short authData and invalid x5c certificate counts.