### PR TITLE
Bind App Attest assertions to challenge payload

### DIFF
--- a/Example/AppAttest-Client-App/AppAttestExample/Client.swift
+++ b/Example/AppAttest-Client-App/AppAttestExample/Client.swift
@@ -86,29 +86,38 @@ enum Client {
       clientDataHash: Data(SHA256.hash(data: challenge))
     )
 
+    let clientData = AssertionClientData(
+      challenge: challenge,
+      keyId: keyId,
+      body: body
+    )
+    let clientDataBytes = try JSONEncoder().encode(clientData)
+
     let assertion = try await DCAppAttestService.shared.generateAssertion(
       keyId,
-      clientDataHash: Data(SHA256.hash(data: body))
+      clientDataHash: Data(SHA256.hash(data: clientDataBytes))
     )
 
     return Payload(
       userId: userId,
       sessionId: sessionId,
-      challenge: challenge,
-      keyId: keyId,
       attestation: attestation,
       assertion: assertion,
-      body: body
+      clientData: clientDataBytes
     )
   }
+}
+
+struct AssertionClientData: Encodable {
+  var challenge: Data
+  var keyId: String
+  var body: Data
 }
 
 struct Payload: Encodable {
   var userId: UUID
   var sessionId: UUID
-  var challenge: Data
-  var keyId: String
   var attestation: Data
   var assertion: Data
-  var body: Data
+  var clientData: Data
 }

--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -55,10 +55,14 @@ actor App {
       struct Payload: Codable {
         let userId: UUID
         let sessionId: UUID
-        let challenge: Data
-        let keyId: String
         let attestation: Data
         let assertion: Data
+        let clientData: Data
+      }
+
+      struct AssertionClientData: Codable {
+        let challenge: Data
+        let keyId: String
         let body: Data
       }
 
@@ -66,31 +70,35 @@ actor App {
         as: Payload.self,
         context: context
       )
+      let clientData = try JSONDecoder().decode(
+        AssertionClientData.self,
+        from: payload.clientData
+      )
 
       try verifyChallenge(
         userId: payload.userId,
         sessionId: payload.sessionId,
-        challengeData: payload.challenge
+        challengeData: clientData.challenge
       )
 
       let attestation = try await appAttest.verifyAttestation(
-        challenge: payload.challenge,
-        keyId: payload.keyId,
+        challenge: clientData.challenge,
+        keyId: clientData.keyId,
         attestation: payload.attestation
       )
 
       try appAttest.verifyAssertion(
         assertion: payload.assertion,
-        payload: payload.body,
+        payload: payload.clientData,
         certificate: attestation.statement.credentialCertificate,
         counter: attestation.authenticatorData.counter
       )
 
-      let newUser = try JSONDecoder().decode(User.self, from: payload.body)
+      let newUser = try JSONDecoder().decode(User.self, from: clientData.body)
 
       users.append(newUser)
 
-      return ByteBuffer(data: payload.body)
+      return ByteBuffer(data: clientData.body)
     }
 
     router.get("users") { _, _ -> ByteBuffer in

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ func sendData(
 
   let body = Body(
     name: "sample name",
-    age: 25
+    age: 25,
+    challenge: challenge,
+    keyId: keyId
   )
 
   let bodyData = try JSONEncoder().encode(body)
@@ -67,12 +69,14 @@ func sendData(
     clientDataHash: Data(SHA256.hash(data: bodyData))
   )
 
-  return (userId, sessionId, challenge, keyId, attestation, assertion, bodyData)
+  return (userId, sessionId, attestation, assertion, bodyData)
 }
 
 struct Body: Codable {
   let name: String
   let age: Int
+  let challenge: Data
+  let keyId: String
 }
 ```
 
@@ -89,8 +93,6 @@ actor App {
   func verifyAndHandleBody(
     userId: UUID,
     sessionId: UUID,
-    challenge: Data,
-    keyId: String,
     attestation: Data,
     assertion: Data,
     bodyData: Data
@@ -109,12 +111,12 @@ actor App {
     try verifyChallenge(
       userId: userId,
       sessionId: sessionId,
-      challengeData: challenge
+      challengeData: body.challenge
     )
     
     let attestation = try await appAttest.verifyAttestation(
-      challenge: challenge,
-      keyId: keyId,
+      challenge: body.challenge,
+      keyId: body.keyId,
       attestation: attestation
     )
   


### PR DESCRIPTION
## Summary
- Update README and examples so assertion client data includes the challenge, key ID, and request body.
- Verify the exact clientData bytes signed by the assertion on the server.
- Read challenge and key ID from the signed client data instead of unsigned adjacent fields.

## Validation
- swift build
- Stack compile check: swift test --filter noSuchTest