### PR TITLE
Return assertion counter from verification

### DIFF
--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -19,6 +19,7 @@ struct Challenge {
 actor App {
   static var users: [User] = []
   static var challenges: [Challenge] = []
+  static var countersByKeyId: [String: UInt32] = [:]
 
   static func main() async throws {
     let appAttest = AppAttest(
@@ -87,12 +88,14 @@ actor App {
         attestation: payload.attestation
       )
 
-      try appAttest.verifyAssertion(
+      let previousCounter = countersByKeyId[payload.keyId] ?? attestation.authenticatorData.counter
+      let counter = try appAttest.verifyAssertion(
         assertion: payload.assertion,
         payload: payload.clientData,
         certificate: attestation.statement.credentialCertificate,
-        counter: attestation.authenticatorData.counter
+        counter: previousCounter
       )
+      countersByKeyId[payload.keyId] = counter
 
       let newUser = try JSONDecoder().decode(User.self, from: clientData.body)
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,13 @@ actor App {
       attestation: attestation
     )
   
-    try appAttest.verifyAssertion(
+    let assertion = try appAttest.verifyAssertion(
       assertion: assertion,
       payload: bodyData,
       certificate: attestation.statement.credentialCertificate,
       counter: attestation.authenticatorData.counter
     )
+    // Store assertion.authenticatorData.counter for the next assertion verification.
     
     print(body.name)
     print(body.age)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ import Foundation
 @main
 actor App {
   var challenges: [Challenge] = []
+  var countersByKeyId: [String: UInt32] = [:]
 
   func verifyAndHandleBody(
     userId: UUID,
@@ -120,13 +121,14 @@ actor App {
       attestation: attestation
     )
   
-    let assertion = try appAttest.verifyAssertion(
+    let previousCounter = countersByKeyId[keyId] ?? attestation.authenticatorData.counter
+    let counter = try appAttest.verifyAssertion(
       assertion: assertion,
       payload: bodyData,
       certificate: attestation.statement.credentialCertificate,
-      counter: attestation.authenticatorData.counter
+      counter: previousCounter
     )
-    // Store assertion.authenticatorData.counter for the next assertion verification.
+    countersByKeyId[keyId] = counter
     
     print(body.name)
     print(body.age)

--- a/Sources/AppAttest/VerifyAssertion.swift
+++ b/Sources/AppAttest/VerifyAssertion.swift
@@ -4,13 +4,12 @@ import PotentCBOR
 import X509
 
 extension AppAttest {
-  @discardableResult
   public func verifyAssertion(
     assertion: Data,
     payload: Data,
     certificate: X509.Certificate,  // credentialCertificate from db attestation
     counter: UInt32  // counter from db attestation
-  ) throws -> Assertion {
+  ) throws -> UInt32 {
     let assertion = try CBORDecoder.default.decode(Assertion.self, from: assertion)
 
     if assertion.authenticatorData.counter <= counter {
@@ -27,7 +26,7 @@ extension AppAttest {
       certificate: certificate
     )
 
-    return assertion
+    return assertion.authenticatorData.counter
   }
 
   static private func verifyNonce(

--- a/Sources/AppAttest/VerifyAssertion.swift
+++ b/Sources/AppAttest/VerifyAssertion.swift
@@ -4,12 +4,13 @@ import PotentCBOR
 import X509
 
 extension AppAttest {
+  @discardableResult
   public func verifyAssertion(
     assertion: Data,
     payload: Data,
     certificate: X509.Certificate,  // credentialCertificate from db attestation
     counter: UInt32  // counter from db attestation
-  ) throws {
+  ) throws -> Assertion {
     let assertion = try CBORDecoder.default.decode(Assertion.self, from: assertion)
 
     if assertion.authenticatorData.counter <= counter {
@@ -25,6 +26,8 @@ extension AppAttest {
       payload: payload,
       certificate: certificate
     )
+
+    return assertion
   }
 
   static private func verifyNonce(

--- a/Tests/AppAttestTests/AppAttestTests.swift
+++ b/Tests/AppAttestTests/AppAttestTests.swift
@@ -64,12 +64,13 @@ func serverCode(
     attestation: attestation
   )
 
-  try appAttest.verifyAssertion(
+  let counter = try appAttest.verifyAssertion(
     assertion: assertion,
     payload: bodyData,
     certificate: attestation.statement.credentialCertificate,
     counter: attestation.authenticatorData.counter
   )
+  _ = counter
 }
 
 @Test

--- a/Tests/AppAttestTests/DataAppAttestTests.swift
+++ b/Tests/AppAttestTests/DataAppAttestTests.swift
@@ -46,10 +46,11 @@ func verifyAttestationAndAssertion(request: Request) async throws {
     attestation: request.attestation
   )
 
-  try appAttest.verifyAssertion(
+  let counter = try appAttest.verifyAssertion(
     assertion: request.assertion,
     payload: request.bodyData,
     certificate: attestation.statement.credentialCertificate,
     counter: attestation.authenticatorData.counter
   )
+  _ = counter
 }


### PR DESCRIPTION
## Summary
- Make verifyAssertion return the verified assertion counter directly.
- Remove discardable-result compatibility so callers are pushed to persist the returned counter.
- Update README, examples, and tests to read the previous counter and store the new one.

## Validation
- swift build
- Stack compile check: swift test --filter noSuchTest

## Stack
Base PR: #58