### PR TITLE
Use App ID prefix for relying party checks

### DIFF
--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -23,7 +23,7 @@ actor App {
 
   static func main() async throws {
     let appAttest = AppAttest(
-      teamId: <#TEAM_ID#>,
+      appIDPrefix: <#APP_ID_PREFIX#>,
       bundleId: <#BUNDLE_ID#>,
       environment: .development
     )

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ actor App {
     assertion: Data,
     bodyData: Data
   ) async throws {
-    let teamId = ProcessInfo.processInfo.environment["TEAM_ID"]! // PH3HCZ4AK6
+    let appIDPrefix = ProcessInfo.processInfo.environment["APP_ID_PREFIX"]! // PH3HCZ4AK6
     let bundleId = ProcessInfo.processInfo.environment["BUNDLE_ID"]! // com.example.memo
   
     let appAttest = AppAttest(
-      teamId: teamId,
+      appIDPrefix: appIDPrefix,
       bundleId: bundleId,
       environment: .development
     )

--- a/Sources/AppAttest/AppAttest.swift
+++ b/Sources/AppAttest/AppAttest.swift
@@ -4,17 +4,36 @@ import PotentCBOR
 import X509
 
 public struct AppAttest: Sendable {
-  public var teamId: String
+  public var appIDPrefix: String
   public var bundleId: String
   public var environment: Environment
 
+  @available(*, deprecated, message: "Use appIDPrefix instead.")
+  public var teamId: String {
+    get { appIDPrefix }
+    set { appIDPrefix = newValue }
+  }
+
+  public init(
+    appIDPrefix: String,
+    bundleId: String,
+    environment: Environment
+  ) {
+    self.appIDPrefix = appIDPrefix
+    self.bundleId = bundleId
+    self.environment = environment
+  }
+
+  @available(*, deprecated, message: "Use init(appIDPrefix:bundleId:environment:) instead.")
   public init(
     teamId: String,
     bundleId: String,
     environment: Environment
   ) {
-    self.teamId = teamId
-    self.bundleId = bundleId
-    self.environment = environment
+    self.init(
+      appIDPrefix: teamId,
+      bundleId: bundleId,
+      environment: environment
+    )
   }
 }

--- a/Sources/AppAttest/AppAttest.swift
+++ b/Sources/AppAttest/AppAttest.swift
@@ -8,12 +8,6 @@ public struct AppAttest: Sendable {
   public var bundleId: String
   public var environment: Environment
 
-  @available(*, deprecated, message: "Use appIDPrefix instead.")
-  public var teamId: String {
-    get { appIDPrefix }
-    set { appIDPrefix = newValue }
-  }
-
   public init(
     appIDPrefix: String,
     bundleId: String,
@@ -22,18 +16,5 @@ public struct AppAttest: Sendable {
     self.appIDPrefix = appIDPrefix
     self.bundleId = bundleId
     self.environment = environment
-  }
-
-  @available(*, deprecated, message: "Use init(appIDPrefix:bundleId:environment:) instead.")
-  public init(
-    teamId: String,
-    bundleId: String,
-    environment: Environment
-  ) {
-    self.init(
-      appIDPrefix: teamId,
-      bundleId: bundleId,
-      environment: environment
-    )
   }
 }

--- a/Sources/AppAttest/Assertion.swift
+++ b/Sources/AppAttest/Assertion.swift
@@ -8,7 +8,7 @@ public struct Assertion: Decodable, Sendable, Hashable {
 extension Assertion {
   public struct AuthenticatorData: Decodable, Sendable, Hashable {
     public let rawData: Data
-    /// "\(teamId).\(bundleId)"  SHA256 hash data
+    /// "\(appIDPrefix).\(bundleId)"  SHA256 hash data
     public let relyingPartyId: Data
     public let counter: UInt32
 

--- a/Sources/AppAttest/Attestation.swift
+++ b/Sources/AppAttest/Attestation.swift
@@ -15,7 +15,7 @@ public struct Attestation: Decodable, Sendable, Hashable {
 extension Attestation {
   public struct AuthenticatorData: Decodable, Sendable, Hashable {
     public let rawData: Data
-    /// "\(teamId).\(bundleId)"  SHA256 hash data
+    /// "\(appIDPrefix).\(bundleId)"  SHA256 hash data
     public let relyingPartyId: Data
     public let counter: UInt32
     public let environment: Environment

--- a/Sources/AppAttest/VerifyAssertion.swift
+++ b/Sources/AppAttest/VerifyAssertion.swift
@@ -47,7 +47,7 @@ extension AppAttest {
   }
 
   private func verifyRelyingPartyId(relyingPartyId: Data) throws {
-    let appIdHash = Data(SHA256.hash(data: Data("\(self.teamId).\(self.bundleId)".utf8)))
+    let appIdHash = Data(SHA256.hash(data: Data("\(self.appIDPrefix).\(self.bundleId)".utf8)))
     if relyingPartyId != appIdHash {
       throw VerifyAssertionError.invalidRelyingPartyID
     }

--- a/Sources/AppAttest/VerifyAttestation.swift
+++ b/Sources/AppAttest/VerifyAttestation.swift
@@ -72,7 +72,7 @@ extension AppAttest {
   private func verifyRelyingParty(
     authenticatorData: Attestation.AuthenticatorData
   ) throws {
-    let appId = Data(SHA256.hash(data: Data("\(self.teamId).\(self.bundleId)".utf8)))
+    let appId = Data(SHA256.hash(data: Data("\(self.appIDPrefix).\(self.bundleId)".utf8)))
     if authenticatorData.relyingPartyId != appId {
       throw VerifyAttestationError.invalidRelyingPartyID
     }

--- a/Tests/AppAttestTests/AppAttestTests.swift
+++ b/Tests/AppAttestTests/AppAttestTests.swift
@@ -45,13 +45,13 @@ func serverCode(
   assertion: Data,
   bodyData: Data
 ) async throws {
-  var teamId = Bundle.main.infoDictionary!["AppIdentifierPrefix"]! as! String  // "PU5HXZ4FZ2",
-  teamId.removeLast()
+  var appIDPrefix = Bundle.main.infoDictionary!["AppIdentifierPrefix"]! as! String  // "PU5HXZ4FZ2",
+  appIDPrefix.removeLast()
 
   let bundleId = Bundle.main.bundleIdentifier!  //"com.zunda.TestAppAttest"
 
   let appAttest = AppAttest(
-    teamId: teamId,
+    appIDPrefix: appIDPrefix,
     bundleId: bundleId,
     environment: .development
   )

--- a/Tests/AppAttestTests/DataAppAttestTests.swift
+++ b/Tests/AppAttestTests/DataAppAttestTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 
 struct Request {
-  var teamId: String
+  var appIDPrefix: String
   var bundleId: String
   var environment: Environment
   var challenge: Data
@@ -13,7 +13,7 @@ struct Request {
   var bodyData: Data
 
   init(
-    teamId: String,
+    appIDPrefix: String,
     bundleId: String,
     environment: Environment,
     challenge: String,
@@ -22,7 +22,7 @@ struct Request {
     assertion: String,
     bodyData: String
   ) {
-    self.teamId = teamId
+    self.appIDPrefix = appIDPrefix
     self.bundleId = bundleId
     self.environment = environment
     self.challenge = Data(base64Encoded: challenge)!
@@ -35,7 +35,7 @@ struct Request {
 
 func verifyAttestationAndAssertion(request: Request) async throws {
   let appAttest = AppAttest(
-    teamId: request.teamId,
+    appIDPrefix: request.appIDPrefix,
     bundleId: request.bundleId,
     environment: request.environment
   )


### PR DESCRIPTION
## Summary
- Rename the AppAttest initializer and stored identifier from teamId to appIDPrefix.
- Remove compatibility shims because the package is not widely used yet.
- Update relying party checks, tests, README, and examples to use App ID prefix terminology.

## Validation
- swift test --filter noSuchTest

## Stack
Base PR: #59