### PR TITLE
Fix counter key references

### DIFF
--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -88,7 +88,8 @@ actor App {
         attestation: payload.attestation
       )
 
-      let previousCounter = countersByKeyId[clientData.keyId] ?? attestation.authenticatorData.counter
+      let previousCounter =
+        countersByKeyId[clientData.keyId] ?? attestation.authenticatorData.counter
       let counter = try appAttest.verifyAssertion(
         assertion: payload.assertion,
         payload: payload.clientData,

--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -88,14 +88,14 @@ actor App {
         attestation: payload.attestation
       )
 
-      let previousCounter = countersByKeyId[payload.keyId] ?? attestation.authenticatorData.counter
+      let previousCounter = countersByKeyId[clientData.keyId] ?? attestation.authenticatorData.counter
       let counter = try appAttest.verifyAssertion(
         assertion: payload.assertion,
         payload: payload.clientData,
         certificate: attestation.statement.credentialCertificate,
         counter: previousCounter
       )
-      countersByKeyId[payload.keyId] = counter
+      countersByKeyId[clientData.keyId] = counter
 
       let newUser = try JSONDecoder().decode(User.self, from: clientData.body)
 

--- a/README.md
+++ b/README.md
@@ -121,14 +121,14 @@ actor App {
       attestation: attestation
     )
   
-    let previousCounter = countersByKeyId[keyId] ?? attestation.authenticatorData.counter
+    let previousCounter = countersByKeyId[body.keyId] ?? attestation.authenticatorData.counter
     let counter = try appAttest.verifyAssertion(
       assertion: assertion,
       payload: bodyData,
       certificate: attestation.statement.credentialCertificate,
       counter: previousCounter
     )
-    countersByKeyId[keyId] = counter
+    countersByKeyId[body.keyId] = counter
     
     print(body.name)
     print(body.age)


### PR DESCRIPTION
## Summary
- Use the signed clientData key ID when reading and storing assertion counters in the example server.
- Update the README sample to use body.keyId for the same counter lookup.
- Remove stale keyId references left after moving keyId into signed client data.