### PR TITLE
modernize certificate usage

### DIFF
--- a/Example/AppAttest-Server/Package.resolved
+++ b/Example/AppAttest-Server/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates",
       "state" : {
-        "revision" : "999fd70c7803da89f3904d635a6815a2a7cd7585",
-        "version" : "1.10.0"
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
-        "version" : "3.12.3"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Example/AppAttest-Server/Package.resolved
+++ b/Example/AppAttest-Server/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "60235983163d040f343a489f7e2e77c1918a8bd9",
-        "version" : "1.26.1"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "d013a2b66ee468aade6da1f26c6d55cb6cd2e9ad",
-        "version" : "5.5.2"
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird",
       "state" : {
-        "revision" : "de2ff8249862791a8972842fd13bff014e71a329",
-        "version" : "2.14.0"
+        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
+        "version" : "2.22.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/outfoxx/PotentCodables",
       "state" : {
-        "revision" : "1f46aa4840e27fcbbcf1ec7a238fcfaadd739abb",
-        "version" : "3.5.1"
+        "revision" : "be0593a39fa3c8203dd10bdbad3803435517c100",
+        "version" : "3.5.3"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
-        "version" : "1.3.2"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -105,7 +105,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
         "version" : "1.2.0"
       }
     },
@@ -123,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "a64a0abc2530f767af15dd88dda7f64d5f1ff9de",
-        "version" : "1.2.0"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -132,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "db6eea3692638a65e2124990155cd220c2915903",
-        "version" : "1.3.0"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -141,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -150,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -159,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
-        "version" : "2.7.0"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -168,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -177,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "24cb15c9bc05e3e9eb5ebaf3d28517d42537bfb1",
-        "version" : "1.27.1"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -186,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
-        "version" : "1.36.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -195,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4b38f35946d00d8f6176fe58f96d83aba64b36c7",
-        "version" : "2.31.0"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -204,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
-        "version" : "1.24.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
@@ -213,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
-        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
-        "version" : "1.0.3"
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -222,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context.git",
       "state" : {
-        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
-        "version" : "1.2.0"
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
       }
     },
     {
@@ -231,17 +240,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
-        "version" : "2.8.0"
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
+      "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
-        "version" : "1.4.2"
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     }
   ],

--- a/Example/AppAttest-Server/Package.swift
+++ b/Example/AppAttest-Server/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .macOS(.v14)
   ],
   dependencies: [
-    .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.0.1"),
+    .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.1"),
     .package(name: "appattest-swift", path: "../../../appattest-swift"),
   ],
   targets: [

--- a/Example/AppAttest-Server/Sources/Server/Server.swift
+++ b/Example/AppAttest-Server/Sources/Server/Server.swift
@@ -17,9 +17,9 @@ struct Challenge {
 
 @main
 struct Server {
-    static func main() async throws {
-        try await App().run()
-    }
+  static func main() async throws {
+    try await App().run()
+  }
 }
 
 actor App {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
-        "version" : "1.3.2"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
-        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
-        "version" : "1.0.3"
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
-        "version" : "3.12.3"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Sources/AppAttest/VerifyAttentionError.swift
+++ b/Sources/AppAttest/VerifyAttentionError.swift
@@ -8,5 +8,4 @@ public enum VerifyAttestationError: Error {
   case invalidKeyId
   case missingExtension
   case couldNotValidateCertificate
-  case failedValidateCertificate
 }

--- a/Sources/AppAttest/VerifyAttestation.swift
+++ b/Sources/AppAttest/VerifyAttestation.swift
@@ -5,8 +5,6 @@ import SwiftASN1
 import X509
 
 extension AppAttest {
-  private static let appAttestNonceExtensionOID: ASN1ObjectIdentifier = [1, 2, 840, 113635, 100, 8, 2]
-
   public func verifyAttestation(
     challenge: Data,
     keyId: String,
@@ -60,7 +58,7 @@ extension AppAttest {
   ) throws {
     let clientDataHash = Data(SHA256.hash(data: challenge))
     let nonceData = Data(SHA256.hash(data: authenticateData.rawData + clientDataHash))
-    guard let ext = credentialCertificate.extensions[oid: Self.appAttestNonceExtensionOID] else {
+    guard let ext = credentialCertificate.extensions[oid: .appAttestNonce] else {
       throw VerifyAttestationError.missingExtension
     }
     let octet = try SingleOctetSequence(derEncoded: ext.value)
@@ -136,16 +134,22 @@ extension AppAttest {
       )
     }
 
-    switch await verifier.validate(
+    let result = await verifier.validate(
       leaf: credentialCertificate,
       intermediates: .init([intermediateCertificateAuthority])
-    ) {
+    )
+
+    switch result {
     case .couldNotValidate:
       throw VerifyAttestationError.couldNotValidateCertificate
     case .validCertificate:
       break
     }
   }
+}
+
+extension ASN1ObjectIdentifier {
+  static let appAttestNonce: ASN1ObjectIdentifier = [1, 2, 840, 113635, 100, 8, 2]
 }
 
 private struct AppleAppAttestationCertificatePolicy: VerifierPolicy, Sendable {

--- a/Sources/AppAttest/VerifyAttestation.swift
+++ b/Sources/AppAttest/VerifyAttestation.swift
@@ -5,6 +5,8 @@ import SwiftASN1
 import X509
 
 extension AppAttest {
+  private static let appAttestNonceExtensionOID: ASN1ObjectIdentifier = [1, 2, 840, 113635, 100, 8, 2]
+
   public func verifyAttestation(
     challenge: Data,
     keyId: String,
@@ -58,12 +60,10 @@ extension AppAttest {
   ) throws {
     let clientDataHash = Data(SHA256.hash(data: challenge))
     let nonceData = Data(SHA256.hash(data: authenticateData.rawData + clientDataHash))
-    let ext = credentialCertificate.extensions.first { $0.oid == [1, 2, 840, 113635, 100, 8, 2] }
-    guard let ext else {
+    guard let ext = credentialCertificate.extensions[oid: Self.appAttestNonceExtensionOID] else {
       throw VerifyAttestationError.missingExtension
     }
-    let der = try DER.parse(ext.value)
-    let octet = try SingleOctetSequence(derEncoded: der.encodedBytes)
+    let octet = try SingleOctetSequence(derEncoded: ext.value)
     if Data(octet.octet.bytes) != nonceData {
       throw VerifyAttestationError.invalidNonce
     }
@@ -129,27 +129,44 @@ extension AppAttest {
     }
 
     var verifier = X509.Verifier(rootCertificates: .init([appleAppAttestationRootCa])) {
-      RFC5280Policy(validationTime: .now)
+      RFC5280Policy()
+      AppleAppAttestationCertificatePolicy(
+        intermediateCertificateAuthority: intermediateCertificateAuthority,
+        rootCertificate: appleAppAttestationRootCa
+      )
     }
 
-    let result = await verifier.validate(
-      leafCertificate: credentialCertificate,
+    switch await verifier.validate(
+      leaf: credentialCertificate,
       intermediates: .init([intermediateCertificateAuthority])
-    )
-
-    switch result {
-    case .couldNotValidate(_):
+    ) {
+    case .couldNotValidate:
       throw VerifyAttestationError.couldNotValidateCertificate
-    case .validCertificate(let certificates):
-      let allCertificates = [
-        appleAppAttestationRootCa,
-        credentialCertificate,
-        intermediateCertificateAuthority,
-      ]
-      if Set(certificates) != Set(allCertificates) {
-        throw VerifyAttestationError.failedValidateCertificate
-      }
+    case .validCertificate:
+      break
     }
+  }
+}
+
+private struct AppleAppAttestationCertificatePolicy: VerifierPolicy, Sendable {
+  var intermediateCertificateAuthority: Certificate
+  var rootCertificate: Certificate
+
+  var verifyingCriticalExtensions: [ASN1ObjectIdentifier] {
+    []
+  }
+
+  mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+    let certificates = Array(chain)
+    guard
+      certificates.count == 3,
+      certificates[1] == intermediateCertificateAuthority,
+      certificates[2] == rootCertificate
+    else {
+      return .failsToMeetPolicy(reason: "Invalid Apple App Attestation certificate chain")
+    }
+
+    return .meetsPolicy
   }
 }
 

--- a/Sources/AppAttest/VerifyAttestation.swift
+++ b/Sources/AppAttest/VerifyAttestation.swift
@@ -160,7 +160,9 @@ private struct AppleAppAttestationCertificatePolicy: VerifierPolicy, Sendable {
     []
   }
 
-  mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+  mutating func chainMeetsPolicyRequirements(
+    chain: UnverifiedCertificateChain
+  ) async -> PolicyEvaluationResult {
     let certificates = Array(chain)
     guard
       certificates.count == 3,


### PR DESCRIPTION
## Summary

- Modernize App Attest certificate verification for the latest `swift-certificates` APIs.
- Use `Certificate.Extensions` OID lookup and direct DER decoding for the App Attest nonce extension.
- Move App Attest certificate chain requirements into a `VerifierPolicy` instead of validating the returned chain with a post-validation `Set` comparison.
- Remove the obsolete `VerifyAttestationError.failedValidateCertificate` case and collapse certificate validation failures into `couldNotValidateCertificate`.
- Update resolved dependencies for `swift-certificates` / `swift-crypto` and related transitive packages.

## Verification

- `swift build` succeeds.