### PR TITLE
Replace CBOR library with brokenhandsio/swift-cbor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "521362b8c3495ada0471a4b86e497b8c5bfc246c55d681115f2907e284716818",
+  "originHash" : "94a1626247a4ca13030d4e953f2d21caa41092a0c7232f589b5f6171bc07089e",
   "pins" : [
-    {
-      "identity" : "cbor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/edgeengineer/cbor",
-      "state" : {
-        "revision" : "a64323cc11eb8b4d7005dfd2feadacfd5f59f547",
-        "version" : "0.0.6"
-      }
-    },
     {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
@@ -17,6 +8,15 @@
       "state" : {
         "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
         "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-cbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/brokenhandsio/swift-cbor",
+      "state" : {
+        "revision" : "96763b161e68a49638c27310aaba04253d7e2c66",
+        "version" : "0.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
   name: "appattest-swift",
   platforms: [
-    .macOS(.v14),
-    .iOS(.v17),
+    .macOS(.v26),
+    .iOS(.v26),
   ],
   products: [
     .library(
@@ -16,14 +16,14 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/edgeengineer/cbor", from: "0.0.6"),
+    .package(url: "https://github.com/brokenhandsio/swift-cbor", from: "0.0.1"),
     .package(url: "https://github.com/apple/swift-certificates", from: "1.19.0"),
   ],
   targets: [
     .target(
       name: "AppAttest",
       dependencies: [
-        .product(name: "CBOR", package: "cbor"),
+        .product(name: "CBOR", package: "swift-cbor"),
         .product(name: "X509", package: "swift-certificates"),
       ],
       resources: [


### PR DESCRIPTION
## 概要

CBOR ライブラリを `edgeengineer/cbor` から `brokenhandsio/swift-cbor` へ置き換えました。

## 変更点

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 依存先 | `edgeengineer/cbor` (from 0.0.6) | `brokenhandsio/swift-cbor` (from 0.0.1) |
| `.product` package 名 | `cbor` | `swift-cbor` |
| swift-tools-version | 6.0 | 6.3 |
| プラットフォーム | macOS 14 / iOS 17 | macOS 26 / iOS 26 |

両ライブラリとも製品名は `CBOR` で、`CBORDecoder().decode(_:from: [UInt8])` という同一 API を提供するため、**ソースコードの変更は不要**でした（`import CBOR` と既存の `Decodable` モデルはそのまま動作）。

## ⚠️ 破壊的変更

`brokenhandsio/swift-cbor` 0.0.1 が macOS 26 / iOS 26 を要求するため、最低プラットフォームと swift-tools-version を引き上げています。旧 OS のサポートは失われます。

## 検証

- `swift build` 成功
- CBOR デコードを通すテストがすべて成功（`assertionAuthenticatorDataRejectsShortInput` / `attestationAuthenticatorDataRejectsShortInput` / `attestationStatementRejectsInvalidCertificateCount`）
- `appAttest()` は `DCAppAttestService.shared.isSupported == false`（実行環境が App Attest 非対応）で失敗しますが、本変更とは無関係の環境起因です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
